### PR TITLE
Fix issues with build

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,5 @@
-[![Gitter](https://badges.gitter.im/crow-lang-org/community.svg)](https://gitter.im/crow-lang-org/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Gitter](https://badges.gitter.im/crow-lang-org/community.svg)]
+(https://gitter.im/crow-lang-org/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 # Crow
 
@@ -11,10 +12,12 @@ For information about the langauge itself, visit the [website](http://crow-lang.
 
 Install these tools (potentially from your operating system's package manager):
 
-* [`git`](https://git-scm.com/) (used to get this repository)
-* [`ldc`](https://github.com/ldc-developers/ldc#installation) (used to compile `bin/crow`).
 * [`dmd`](https://dlang.org/download.html#dmd) (used to compile `bin/crow-debug` due to much faster compiles)
-* [`hg`](http://mercurial-scm.org) (used to clone the dyncall library)
+* [`git`](https://git-scm.com/) (used to get this repository)
+* [`hg`](https://mercurial-scm.org) (used to clone the `dyncall` library)
+* [`ldc`](https://github.com/ldc-developers/ldc#installation) (used to compile `bin/crow`).
+	- `wasm-ld` may need to be installed separately (used to compile `bin/crow.wasm`)
+* [`libgccjit`](https://gcc.gnu.org/onlinedocs/jit) (`bin/crow` links to this)
 
 Then run:
 

--- a/src/util/writer.d
+++ b/src/util/writer.d
@@ -24,7 +24,7 @@ immutable(string) finishWriter(scope ref Writer writer) {
 	return finishWriter(writer).ptr;
 }
 
-@trusted immutable(SafeCStr) finishWriterToSafeCStr(ref Writer writer) {
+@trusted immutable(SafeCStr) finishWriterToSafeCStr(scope ref Writer writer) {
 	return immutable SafeCStr(finishWriterToCStr(writer));
 }
 


### PR DESCRIPTION
Fixes #4

* Fix long line in readme that broke linting.
* Add some missing dependencies. Also put them in alphabetical order.
  - On my OpenSUSE machine there is no separate `wasm-ld` dependency, but apparently there is on Arch.
 * Fix an issue with missing `scope` keyword detected by newer versions of `dmd` (tested with 2.098.1)